### PR TITLE
Mark some files as ignored; like yii2 repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,34 @@
+# phpstorm project files
+.idea
+
+# netbeans project files
+nbproject
+
+# zend studio for eclipse project files
+.buildpath
+.project
+.settings
+
+# sublime text project / workspace files
+*.sublime-project
+*.sublime-workspace
+
+# visual studio code project files
+.vscode
+
+# windows thumbnail cache
+Thumbs.db
+
+# Mac DS_Store Files
+.DS_Store
+
+# composer vendor dir
 /vendor
+
+# composer itself is not needed
+composer.phar
+
+# phpunit itself is not needed
+phpunit.phar
+# local phpunit config
+/phpunit.xml


### PR DESCRIPTION
Some values may be removed. I dont sure about this:

```
# composer itself is not needed
composer.phar

# phpunit itself is not needed
phpunit.phar
# local phpunit config
/phpunit.xml
```

Also, may be we need another files in gitignore
```

# composer.lock in applications is ignored since it's automatically created by composer when application is installed
/apps/*/composer.lock


# cubrid install dir
/cubrid

# ignore dev installed apps and extensions
/apps
/extensions
/packages

# NPM packages
/node_modules
.env

```

let's disscus!

| Q             | A
| ------------- | ---
| Is bugfix?    | yes/no
| New feature?  | yes/no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | 
