### PR TITLE
Friendly Exception support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
     "require": {
         "php": "^7.2.0",
         "hiqdev/composer-config-plugin": "^1.0@dev",
-        "symfony/console": "^4.3"
+        "symfony/console": "^4.3",
+        "yiisoft/friendly-exception": "@dev"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.3",

--- a/src/Application.php
+++ b/src/Application.php
@@ -1,6 +1,10 @@
 <?php
 namespace Yiisoft\Yii\Console;
 
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\StyleInterface;
+use Yiisoft\FriendlyException\FriendlyExceptionInterface;
+
 class Application extends \Symfony\Component\Console\Application
 {
     public const VERSION = '1.0.0';
@@ -8,5 +12,24 @@ class Application extends \Symfony\Component\Console\Application
     public function __construct(string $name = 'Yii Console', string $version = self::VERSION)
     {
         parent::__construct($name, $version);
+    }
+
+    public function doRenderException(\Exception $e, OutputInterface $output)
+    {
+        parent::doRenderException($e, $output);
+        // Friendly Exception support
+        if ($e instanceof FriendlyExceptionInterface) {
+            if ($output instanceof StyleInterface) {
+                $output->title($e->getName());
+                $output->note($e->getSolution());
+                $output->newLine();
+            } else {
+                $output->writeln([
+                    '<fg=red>' . $e->getName() . '</>',
+                    '<fg=yellow>' . $e->getSolution() . '</>',
+                    '',
+                ]);
+            }
+        }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | 

If exception is implements [FriendlyExceptionInterface](https://github.com/yiisoft/friendly-exception/blob/master/src/FriendlyExceptionInterface.php) then `exception->name` and `exception->solution` will be printed in the end

Example:
![image](https://user-images.githubusercontent.com/4152481/67812161-7d4e1200-faaf-11e9-9ec9-57c5c7f2be91.png)
