### PR TITLE
Add EventDispatcherInterface

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
         "php": "^7.4",
         "yiisoft/composer-config-plugin": "^1.0@dev",
         "symfony/console": "^5.0|^4.0",
+        "symfony/event-dispatcher-contracts": "^2.0",
         "yiisoft/friendly-exception": "^1.0",
         "psr/container": "1.0.0",
         "psr/container-implementation": "1.0.0"


### PR DESCRIPTION
Fix for: Fatal error: Uncaught Error: Interface 'Symfony\Contracts\EventDispatcher\EventDispatcherInterface' not found in /Users/jhamrak/Downloads/yii-demo-master/.pages/vendor/yiisoft/yii-console/src/SymfonyEventDispatcher.php:8

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | 
