### PR TITLE
Fix dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,12 +19,14 @@
     "prefer-stable": true,
     "require": {
         "php": "^7.4",
-        "yiisoft/composer-config-plugin": "^1.0@dev",
+        "psr/container": "1.0.0",
+        "psr/container-implementation": "1.0.0",
         "symfony/console": "^5.0|^4.0",
         "symfony/event-dispatcher-contracts": "^2.0",
+        "yiisoft/composer-config-plugin": "^1.0@dev",
+        "yiisoft/event-dispatcher": "^3.0@dev",
         "yiisoft/friendly-exception": "^1.0",
-        "psr/container": "1.0.0",
-        "psr/container-implementation": "1.0.0"
+        "yiisoft/injector": "^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | ❌

We need this since [`Yiisoft\Yii\Console\Config\EventConfigurator`](https://github.com/yiisoft/yii-console/blob/bbf7fa3acf3763f4cacd55695359b0181cfb8dad/src/Config/EventConfigurator.php) depends on `Yiisoft\EventDispatcher\Provider\Provider` and `Yiisoft\Injector\Injector`.