### PR TITLE
Fix using event configurator with DI references

### DIFF
--- a/src/Config/EventConfigurator.php
+++ b/src/Config/EventConfigurator.php
@@ -54,14 +54,22 @@ class EventConfigurator extends AbstractProviderConfigurator
             return true;
         }
 
-        return is_array($definition)
-            && array_keys($definition) === [0, 1]
-            && (
-                in_array($definition[1], get_class_methods($definition[0]) ?? [], true)
-                || (
-                    $this->container->has($definition[0])
-                    && method_exists($this->container->get($definition[0]), $definition[1])
-                )
-            );
+        if (is_array($definition) && array_keys($definition) === [0, 1]) {
+            if (
+                is_string($definition[0])
+                && class_exists($definition[0])
+                && in_array($definition[1], get_class_methods($definition[0]) ?? [], true)
+            ) {
+                return true;
+            }
+
+            if ((is_string($definition[0]) || is_object($definition[0])) && $this->container->has($definition[0])) {
+                $object = $this->container->get($definition[0]);
+
+                return method_exists($object, $definition[1]);
+            }
+        }
+
+        return false;
     }
 }

--- a/src/Config/EventConfigurator.php
+++ b/src/Config/EventConfigurator.php
@@ -54,20 +54,15 @@ class EventConfigurator extends AbstractProviderConfigurator
             return true;
         }
 
-        if (is_array($definition) && array_keys($definition) === [0, 1]) {
-            if (
-                is_string($definition[0])
-                && class_exists($definition[0])
-                && in_array($definition[1], get_class_methods($definition[0]) ?? [], true)
-            ) {
-                return true;
-            }
+        if (
+            is_array($definition)
+            && array_keys($definition) === [0, 1]
+            && is_string($definition[0])
+            && $this->container->has($definition[0])
+        ) {
+            $object = $this->container->get($definition[0]);
 
-            if ((is_string($definition[0]) || is_object($definition[0])) && $this->container->has($definition[0])) {
-                $object = $this->container->get($definition[0]);
-
-                return method_exists($object, $definition[1]);
-            }
+            return method_exists($object, $definition[1]);
         }
 
         return false;

--- a/src/Config/EventConfigurator.php
+++ b/src/Config/EventConfigurator.php
@@ -54,6 +54,14 @@ class EventConfigurator extends AbstractProviderConfigurator
             return true;
         }
 
-        return is_array($definition) && array_keys($definition) === [0, 1] && in_array($definition[1], get_class_methods($definition[0]) ?? [], true);
+        return is_array($definition)
+            && array_keys($definition) === [0, 1]
+            && (
+                in_array($definition[1], get_class_methods($definition[0]) ?? [], true)
+                || (
+                    $this->container->has($definition[0])
+                    && method_exists($this->container->get($definition[0]), $definition[1])
+                )
+            );
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | ❌

Fixing usage with aliases in DI configuration:
`['someAlias' => ClassName::class]` in DI configuration and `['someALias', 'methodName']` in `events-console.php`.