### PR TITLE
Add rebuildConfigs param and set configs dir via option in command line

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,5 +31,9 @@ composer.phar
 
 # phpunit itself is not needed
 phpunit.phar
+
 # local phpunit config
 /phpunit.xml
+
+# phpunit cache
+.phpunit.result.cache

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ To start working with the package you must do one of these:
 Since the package is based on [Symfony Console component](https://symfony.com/doc/current/components/console.html),
 refer to its documentation for details on how to use the binary and create your own commands.
 
-### Using alternative sets of configurations 
+### Using alternative set of configurations 
 
 Use option `--config` (`-c`) for set name of alterntaive configuration:
 
@@ -35,10 +35,10 @@ vendor\bin\yii -ctest
 vendor\bin\yii --config=test
 ``` 
 
-For more info about alternative sets of configurations and usage see its 
+For more info about alternative configuration sets their and usage see its  
 [documentation](https://github.com/yiisoft/composer-config-plugin/blob/master/docs/en/alternatives.md).
 
-### Parameters of console
+### Console parameters
 
 ##### rebuildConfig
  
@@ -49,7 +49,7 @@ Default Value:
 static fn() => getenv('APP_ENV') === 'dev'
 ```
 
-Force rebuild configuration before each run console.
+Force rebuild configuration before each run.
 
 Don't do it in production, assembling takes it's time.
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,6 @@ return [
 ];
 ```
 
-
 ### Unit testing
 
 The package is tested with [PHPUnit](https://phpunit.de/). To run tests:

--- a/README.md
+++ b/README.md
@@ -38,6 +38,34 @@ vendor\bin\yii --config=test
 For more info about alternative sets of configurations and usage see its 
 [documentation](https://github.com/yiisoft/composer-config-plugin/blob/master/docs/en/alternatives.md).
 
+### Parameters of console
+
+##### rebuildConfig
+ 
+Type: `bool|\Closure`
+
+Default Value: 
+```php
+static fn() => getenv('APP_ENV') === 'dev'
+```
+
+Force rebuild configuration before each run console.
+
+Don't do it in production, assembling takes it's time.
+
+#### Override parameters
+
+You can override this params via `config/params.php` in your application. For example:
+
+```php
+return [
+    'yiisoft/yii-console' => [
+        'rebuildConfig' => true,
+    ],
+];
+```
+
+
 ### Unit testing
 
 The package is tested with [PHPUnit](https://phpunit.de/). To run tests:

--- a/README.md
+++ b/README.md
@@ -26,6 +26,18 @@ To start working with the package you must do one of these:
 Since the package is based on [Symfony Console component](https://symfony.com/doc/current/components/console.html),
 refer to its documentation for details on how to use the binary and create your own commands.
 
+### Using alternative sets of configurations 
+
+Use option `--config` (`-c`) for set name of alterntaive configuration:
+
+```
+vendor\bin\yii -ctest
+vendor\bin\yii --config=test
+``` 
+
+For more info about alternative sets of configurations and usage see its 
+[documentation](https://github.com/yiisoft/composer-config-plugin/blob/master/docs/en/alternatives.md).
+
 ### Unit testing
 
 The package is tested with [PHPUnit](https://phpunit.de/). To run tests:

--- a/bin/yii
+++ b/bin/yii
@@ -49,10 +49,10 @@ use Yiisoft\Yii\Console\Output\ConsoleBufferedOutput;
 
     $params = (require Builder::path($configsDir . 'params'))['yiisoft/yii-console'];
 
-    $rebuildConfigs = $params['rebuildConfigs'] instanceof Closure ?
-        $params['rebuildConfigs']() :
-        $params['rebuildConfigs'];
-    if ($rebuildConfigs) {
+    $rebuildConfig = $params['rebuildConfig'] instanceof Closure ?
+        $params['rebuildConfig']() :
+        $params['rebuildConfig'];
+    if ($rebuildConfig) {
         // Don't do it in production, assembling takes it's time
         Builder::rebuild();
     }

--- a/bin/yii
+++ b/bin/yii
@@ -44,14 +44,23 @@ use Yiisoft\Yii\Console\Output\ConsoleBufferedOutput;
 
     require_once $autoloadPath;
 
-    $configsDir = getopt('c:');
-    $configsDir = $configsDir ? $configsDir['c'] . '/' : '';
+    $cliOptions = getopt('c:r', ['config:', 'rebuild-config']);
+
+    $configsDir = '';
+    if (array_key_exists('config', $cliOptions)) {
+        $configsDir = $cliOptions['config'] . '/';
+    } elseif (array_key_exists('c', $cliOptions)) {
+        $configsDir = $cliOptions['c'] . '/';
+    }
 
     $params = (require Builder::path($configsDir . 'params'))['yiisoft/yii-console'];
 
-    $rebuildConfig = $params['rebuildConfig'] instanceof Closure ?
-        $params['rebuildConfig']() :
-        $params['rebuildConfig'];
+    $rebuildConfig = array_key_exists('r', $cliOptions) || array_key_exists('rebuild-config', $cliOptions);
+    if (!$rebuildConfig) {
+        $rebuildConfig = $params['rebuildConfig'] instanceof Closure ?
+            $params['rebuildConfig']() :
+            $params['rebuildConfig'];
+    }
     if ($rebuildConfig) {
         // Don't do it in production, assembling takes it's time
         Builder::rebuild();

--- a/bin/yii
+++ b/bin/yii
@@ -49,12 +49,14 @@ use Yiisoft\Yii\Console\Output\ConsoleBufferedOutput;
 
     $params = (require Builder::path($configsDir . 'params'))['yiisoft/yii-console'];
 
-    // Don't do it in production, assembling takes it's time
-    if ($params['rebuildConfigs']) {
+    $rebuildConfigs = $params['rebuildConfigs'] instanceof Closure ?
+        $params['rebuildConfigs']() :
+        $params['rebuildConfigs'];
+    if ($rebuildConfigs) {
+        // Don't do it in production, assembling takes it's time
         Builder::rebuild();
     }
 
-    $containerParams = $params['container'];
     $container = new Container(
         require Builder::path($configsDir . 'console'),
         require Builder::path($configsDir . 'providers-console')

--- a/bin/yii
+++ b/bin/yii
@@ -44,20 +44,20 @@ use Yiisoft\Yii\Console\Output\ConsoleBufferedOutput;
 
     require_once $autoloadPath;
 
-    $paramsConfig = getopt('p:');
-    $paramsConfig = $paramsConfig ? $paramsConfig['p'] : 'params';
-    $params = (require Builder::path($paramsConfig))['yiisoft/yii-console'];
+    $configsDir = getopt('c:');
+    $configsDir = $configsDir ? $configsDir['c'] . '/' : '';
+
+    $params = (require Builder::path($configsDir . 'params'))['yiisoft/yii-console'];
 
     // Don't do it in production, assembling takes it's time
     if ($params['rebuildConfigs']) {
         Builder::rebuild();
-        $params = (require Builder::path($paramsConfig))['yiisoft/yii-console'];
     }
 
     $containerParams = $params['container'];
     $container = new Container(
-        require Builder::path($containerParams['definitionsConfig']),
-        require Builder::path($containerParams['providersConfig'])
+        require Builder::path($configsDir . 'console'),
+        require Builder::path($configsDir . 'providers-console')
     );
 
     /** @var ContainerInterface $container */

--- a/bin/yii
+++ b/bin/yii
@@ -44,12 +44,14 @@ use Yiisoft\Yii\Console\Output\ConsoleBufferedOutput;
 
     require_once $autoloadPath;
 
-    $params = (require Builder::path('params'))['yiisoft/yii-console'];
+    $paramsConfig = getopt('p:');
+    $paramsConfig = $paramsConfig ? $paramsConfig['p'] : 'params';
+    $params = (require Builder::path($paramsConfig))['yiisoft/yii-console'];
 
     // Don't do it in production, assembling takes it's time
     if ($params['rebuildConfigs']) {
         Builder::rebuild();
-        $params = (require Builder::path('params'))['yiisoft/yii-console'];
+        $params = (require Builder::path($paramsConfig))['yiisoft/yii-console'];
     }
 
     $containerParams = $params['container'];

--- a/bin/yii
+++ b/bin/yii
@@ -44,7 +44,7 @@ use Yiisoft\Yii\Console\Output\ConsoleBufferedOutput;
 
     require_once $autoloadPath;
 
-    $cliOptions = getopt('c:r', ['config:', 'rebuild-config']);
+    $cliOptions = getopt('c:', ['config:']);
 
     $configsDir = '';
     if (array_key_exists('config', $cliOptions)) {
@@ -55,12 +55,10 @@ use Yiisoft\Yii\Console\Output\ConsoleBufferedOutput;
 
     $params = (require Builder::path($configsDir . 'params'))['yiisoft/yii-console'];
 
-    $rebuildConfig = array_key_exists('r', $cliOptions) || array_key_exists('rebuild-config', $cliOptions);
-    if (!$rebuildConfig) {
-        $rebuildConfig = $params['rebuildConfig'] instanceof Closure
-            ? $params['rebuildConfig']()
-            : $params['rebuildConfig'];
-    }
+    $rebuildConfig = $params['rebuildConfig'] instanceof Closure
+        ? $params['rebuildConfig']()
+        : $params['rebuildConfig'];
+
     if ($rebuildConfig) {
         // Don't do it in production, assembling takes it's time
         Builder::rebuild();

--- a/bin/yii
+++ b/bin/yii
@@ -49,9 +49,12 @@ use Yiisoft\Yii\Console\Output\ConsoleBufferedOutput;
         Builder::rebuild();
     }
 
+    $params = (require Builder::path('params'))['yiisoft/yii-console'];
+    $containerParams = $params['container'];
+
     $container = new Container(
-        require Builder::path('console'),
-        require Builder::path('providers-console')
+        require Builder::path($containerParams['definitionsConfig']),
+        require Builder::path($containerParams['providersConfig'])
     );
 
     /** @var ContainerInterface $container */

--- a/bin/yii
+++ b/bin/yii
@@ -44,14 +44,15 @@ use Yiisoft\Yii\Console\Output\ConsoleBufferedOutput;
 
     require_once $autoloadPath;
 
+    $params = (require Builder::path('params'))['yiisoft/yii-console'];
+
     // Don't do it in production, assembling takes it's time
-    if (getenv('APP_ENV') === 'dev') {
+    if ($params['rebuildConfigs']) {
         Builder::rebuild();
+        $params = (require Builder::path('params'))['yiisoft/yii-console'];
     }
 
-    $params = (require Builder::path('params'))['yiisoft/yii-console'];
     $containerParams = $params['container'];
-
     $container = new Container(
         require Builder::path($containerParams['definitionsConfig']),
         require Builder::path($containerParams['providersConfig'])

--- a/bin/yii
+++ b/bin/yii
@@ -57,9 +57,9 @@ use Yiisoft\Yii\Console\Output\ConsoleBufferedOutput;
 
     $rebuildConfig = array_key_exists('r', $cliOptions) || array_key_exists('rebuild-config', $cliOptions);
     if (!$rebuildConfig) {
-        $rebuildConfig = $params['rebuildConfig'] instanceof Closure ?
-            $params['rebuildConfig']() :
-            $params['rebuildConfig'];
+        $rebuildConfig = $params['rebuildConfig'] instanceof Closure
+            ? $params['rebuildConfig']()
+            : $params['rebuildConfig'];
     }
     if ($rebuildConfig) {
         // Don't do it in production, assembling takes it's time

--- a/config/params.php
+++ b/config/params.php
@@ -12,6 +12,6 @@ return [
             'serve' => Serve::class,
         ],
         'version' => '3.0',
-        'rebuildConfigs' => getenv('APP_ENV') === 'dev',
+        'rebuildConfigs' => static fn() => getenv('APP_ENV') === 'dev',
     ],
 ];

--- a/config/params.php
+++ b/config/params.php
@@ -13,9 +13,5 @@ return [
         ],
         'version' => '3.0',
         'rebuildConfigs' => getenv('APP_ENV') === 'dev',
-        'container' => [
-            'definitionsConfig' => 'console',
-            'providersConfig' => 'providers-console',
-        ],
     ],
 ];

--- a/config/params.php
+++ b/config/params.php
@@ -11,6 +11,10 @@ return [
         'commands' => [
             'serve' => Serve::class,
         ],
-        'version' => '3.0'
+        'version' => '3.0',
+        'container' => [
+            'definitionsConfig' => 'console',
+            'providersConfig' => 'providers-console',
+        ],
     ],
 ];

--- a/config/params.php
+++ b/config/params.php
@@ -12,6 +12,7 @@ return [
             'serve' => Serve::class,
         ],
         'version' => '3.0',
+        'rebuildConfigs' => getenv('APP_ENV') === 'dev',
         'container' => [
             'definitionsConfig' => 'console',
             'providersConfig' => 'providers-console',

--- a/config/params.php
+++ b/config/params.php
@@ -12,6 +12,6 @@ return [
             'serve' => Serve::class,
         ],
         'version' => '3.0',
-        'rebuildConfigs' => static fn() => getenv('APP_ENV') === 'dev',
+        'rebuildConfig' => static fn() => getenv('APP_ENV') === 'dev',
     ],
 ];

--- a/src/Provider/ApplicationProvider.php
+++ b/src/Provider/ApplicationProvider.php
@@ -43,9 +43,10 @@ final class ApplicationProvider extends ServiceProvider
 
             $application->setCommandLoader($loader);
 
-            $application->getDefinition()->addOption(
-                new InputOption('config-dir', 'c', InputOption::VALUE_OPTIONAL, 'Set configs directory'),
-            );
+            $application->getDefinition()->addOptions([
+                new InputOption('config', 'c', InputOption::VALUE_REQUIRED, 'Set alternative configuration name'),
+                new InputOption('rebuild-config', 'r', InputOption::VALUE_NONE, 'Force rebuild configuration'),
+            ]);
 
             if ($this->name !== '') {
                 $application->setName($this->name);

--- a/src/Provider/ApplicationProvider.php
+++ b/src/Provider/ApplicationProvider.php
@@ -6,6 +6,7 @@ namespace Yiisoft\Yii\Console\Provider;
 
 use Psr\Container\ContainerInterface;
 use Symfony\Component\Console\CommandLoader\ContainerCommandLoader;
+use Symfony\Component\Console\Input\InputOption;
 use Yiisoft\Di\Container;
 use Yiisoft\Di\Support\ServiceProvider;
 use Yiisoft\Yii\Console\Application;
@@ -41,6 +42,10 @@ final class ApplicationProvider extends ServiceProvider
             );
 
             $application->setCommandLoader($loader);
+
+            $application->getDefinition()->addOption(
+                new InputOption('params', 'p', InputOption::VALUE_OPTIONAL, 'Set params config name'),
+            );
 
             if ($this->name !== '') {
                 $application->setName($this->name);

--- a/src/Provider/ApplicationProvider.php
+++ b/src/Provider/ApplicationProvider.php
@@ -44,7 +44,7 @@ final class ApplicationProvider extends ServiceProvider
             $application->setCommandLoader($loader);
 
             $application->getDefinition()->addOption(
-                new InputOption('params', 'p', InputOption::VALUE_OPTIONAL, 'Set params config name'),
+                new InputOption('config-dir', 'c', InputOption::VALUE_OPTIONAL, 'Set configs directory'),
             );
 
             if ($this->name !== '') {

--- a/src/Provider/ApplicationProvider.php
+++ b/src/Provider/ApplicationProvider.php
@@ -43,10 +43,9 @@ final class ApplicationProvider extends ServiceProvider
 
             $application->setCommandLoader($loader);
 
-            $application->getDefinition()->addOptions([
+            $application->getDefinition()->addOption(
                 new InputOption('config', 'c', InputOption::VALUE_REQUIRED, 'Set alternative configuration name'),
-                new InputOption('rebuild-config', 'r', InputOption::VALUE_NONE, 'Force rebuild configuration'),
-            ]);
+            );
 
             if ($this->name !== '') {
                 $application->setName($this->name);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    |  ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | -

1) For use [alternative configs](https://github.com/yiisoft/composer-config-plugin/blob/master/docs/en/alternatives.md) run console with option `-c` or `--config`, for example:
`vendor\bin\yii -ctest`
`vendor\bin\yii --config=test`

2) Add option `-r` or `--rebuild-config` for force rebuild configuration. For example:
`vendor\bin\yii -r`
`vendor\bin\yii --rebuild-config`

3) In params added options `rebuildConfig` for check rebuild configs or not.