### PR TITLE
Add support parameter --config as array

### DIFF
--- a/bin/yii
+++ b/bin/yii
@@ -44,13 +44,14 @@ use Yiisoft\Yii\Console\Output\ConsoleBufferedOutput;
 
     require_once $autoloadPath;
 
-    $cliOptions = getopt('c:', ['config:']);
+    $cliOptions = getopt('', ['config:']);
 
     $configsDir = '';
     if (array_key_exists('config', $cliOptions)) {
-        $configsDir = $cliOptions['config'] . '/';
-    } elseif (array_key_exists('c', $cliOptions)) {
-        $configsDir = $cliOptions['c'] . '/';
+        $configsDir = is_array($cliOptions['config'])
+            ? $cliOptions['config'][array_key_last($cliOptions['config'])]
+            : $cliOptions['config'];
+        $configsDir .= '/';
     }
 
     $params = (require Builder::path($configsDir . 'params'))['yiisoft/yii-console'];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | -

When run `yii` with several arguments `--config` last argument is used.

### Use case

Create in app batch file with set default config.

```batch
@echo off
@setlocal

set YII_PATH=%~dp0

if "%PHP_COMMAND%" == "" set PHP_COMMAND=php.exe

"%PHP_COMMAND%" "%YII_PATH%vendor/yiisoft/yii-console/bin/yii" --config=console %*

@endlocal
```

Without this PR run so throws error:

```shell
./yii --config=front
```