### PR TITLE
Add providers configuration.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,8 @@
         },
         "config-plugin": {
             "params": "config/params.php",
-            "console": "config/console.php"
+            "console": "config/console.php",
+            "providers-console": "config/providers-console.php"
         },
         "config-plugin-dev": {
             "tests": [

--- a/config/providers-console.php
+++ b/config/providers-console.php
@@ -1,0 +1,5 @@
+<?php
+
+declare(strict_types=1);
+
+return [];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | -

Reason: when use `yii-console` in app without `providers-console` configuration throws exception:
```
Fatal error: Uncaught Error: Failed opening required '.../runtime/config/console/providers-console.php' (include_path='.') in ...\vendor\yiisoft\yii-console\bin\yii:70
```