### PR TITLE
Raise symfony/console dependency version to "^5.3"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     "require": {
         "php": "^7.4|^8.0",
         "psr/container": "^1.0|^2.0",
-        "symfony/console": "^5.1.8",
+        "symfony/console": "^5.3",
         "symfony/event-dispatcher-contracts": "^2.2",
         "yiisoft/friendly-exception": "^1.0"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | -
