### PR TITLE
Add return type to CommandLoader::get() method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.0.1 under development
 
 - Enh #141: Add support for version `^6.0` for `symfony/console` package (devanych)
+- Bug #145: Add return type to `Yiisoft\Yii\Console\CommandLoader::get()` method (devanych)
 
 ## 1.0.0 November 01, 2021
 

--- a/src/CommandLoader.php
+++ b/src/CommandLoader.php
@@ -44,7 +44,7 @@ final class CommandLoader implements CommandLoaderInterface
         $this->setCommandMap($commandMap);
     }
 
-    public function get(string $name)
+    public function get(string $name): Command
     {
         if (!$this->has($name)) {
             throw new CommandNotFoundException(sprintf('Command "%s" does not exist.', $name));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | -

BC is compatible. In version `6.0`, typehints were prescribed, which in `5.*` are indicated in the docblocks.