### PR TITLE
Style output, add xdebug shortcut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,13 @@
 # Yii Console Change Log
 
-## 2.0.2 under development
+## 2.1.0 under development
 
-- Bug #179: Remove duplicate message about server address (samdark)
+- Bug #180: Enhance output of `serve` command (@xepozz)
+- Bug #179: Remove duplicate message about server address (@samdark)
 
 ## 2.0.1 March 31, 2023
 
-- Bug #175: Fix `serve` under Windows (samdark)
+- Bug #175: Fix `serve` under Windows (@samdark)
 
 ## 2.0.0 February 17, 2023
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2.1.0 under development
 
-- Bug #180: Enhance output of `serve` command (@xepozz)
+- Enh #180: Enhance output of `serve` command, add `--xdebug` option for `serve` (@xepozz)
 - Bug #179: Remove duplicate message about server address (@samdark)
 
 ## 2.0.1 March 31, 2023

--- a/src/Command/Serve.php
+++ b/src/Command/Serve.php
@@ -80,7 +80,7 @@ final class Serve extends Command
                 $this->defaultWorkers
             )
             ->addOption('env', 'e', InputOption::VALUE_OPTIONAL, 'It is only used for testing.')
-            ->addOption('xdebug', 'x', InputOption::VALUE_OPTIONAL, 'Enables XDEBUG session.');
+            ->addOption('xdebug', 'x', InputOption::VALUE_OPTIONAL, 'Enables XDEBUG session.', false);
     }
 
     public function complete(CompletionInput $input, CompletionSuggestions $suggestions): void
@@ -150,7 +150,7 @@ final class Serve extends Command
         }
 
         $xDebugInstalled = extension_loaded('xdebug');
-        $xDebugEnabled = $isLinux && $xDebugInstalled && $input->hasOption('xdebug');
+        $xDebugEnabled = $isLinux && $xDebugInstalled && $input->hasOption('xdebug') && $input->getOption('xdebug');
 
         if ($xDebugEnabled) {
             $command[] = 'XDEBUG_MODE=debug XDEBUG_TRIGGER=yes';

--- a/src/Command/Serve.php
+++ b/src/Command/Serve.php
@@ -95,7 +95,7 @@ final class Serve extends Command
     {
         $io = new SymfonyStyle($input, $output);
         $io->title('Yii3 Development Server');
-        $io->writeln('https://yiiframework.com'."\n");
+        $io->writeln('https://yiiframework.com' . "\n");
 
         /** @var string $address */
         $address = $input->getArgument('address');

--- a/src/Command/Serve.php
+++ b/src/Command/Serve.php
@@ -141,11 +141,6 @@ final class Serve extends Command
             return self::EXIT_CODE_NO_ROUTING_FILE;
         }
 
-        if ($env === 'test') {
-            return ExitCode::OK;
-        }
-
-
         $command = [];
 
         $isLinux = DIRECTORY_SEPARATOR !== '\\';
@@ -186,6 +181,10 @@ final class Serve extends Command
         ], OutputInterface::VERBOSITY_VERBOSE);
 
         $io->success('Quit the server with CTRL-C or COMMAND-C.');
+
+        if ($env === 'test') {
+            return ExitCode::OK;
+        }
 
         passthru($command, $result);
 

--- a/src/Command/Serve.php
+++ b/src/Command/Serve.php
@@ -94,8 +94,8 @@ final class Serve extends Command
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = new SymfonyStyle($input, $output);
-        $io->title('Yii 3 Development Server.');
-        $io->writeln('https://yiiframework.com');
+        $io->title('Yii3 Development Server');
+        $io->writeln('https://yiiframework.com'."\n");
 
         /** @var string $address */
         $address = $input->getArgument('address');

--- a/tests/ServeCommandTest.php
+++ b/tests/ServeCommandTest.php
@@ -55,7 +55,7 @@ final class ServeCommandTest extends TestCase
 
         $this->assertSame(ExitCode::OK, $commandCreate->getStatusCode());
 
-        $docroot = preg_quote(getcwd() . '/tests', '/');
+        $docroot = preg_quote(getcwd() . DIRECTORY_SEPARATOR . 'tests', '/');
         $this->assertMatchesRegularExpression(
             "/Document root\s+{$docroot}/",
             $output
@@ -88,7 +88,7 @@ final class ServeCommandTest extends TestCase
 
         $this->assertSame(ExitCode::OK, $commandCreate->getStatusCode());
 
-        $docroot = preg_quote(getcwd() . '/tests', '/');
+        $docroot = preg_quote(getcwd() . DIRECTORY_SEPARATOR . 'tests', '/');
         $this->assertMatchesRegularExpression(
             "/Document root\s+{$docroot}/",
             $output

--- a/tests/ServeCommandTest.php
+++ b/tests/ServeCommandTest.php
@@ -55,8 +55,9 @@ final class ServeCommandTest extends TestCase
 
         $this->assertSame(ExitCode::OK, $commandCreate->getStatusCode());
 
-        $this->assertStringContainsString(
-            'Document root is',
+        $docroot = preg_quote(getcwd() . '/tests', '/');
+        $this->assertMatchesRegularExpression(
+            "/Document root\s+{$docroot}/",
             $output
         );
 
@@ -87,8 +88,9 @@ final class ServeCommandTest extends TestCase
 
         $this->assertSame(ExitCode::OK, $commandCreate->getStatusCode());
 
-        $this->assertStringContainsString(
-            'Document root is',
+        $docroot = preg_quote(getcwd() . '/tests', '/');
+        $this->assertMatchesRegularExpression(
+            "/Document root\s+{$docroot}/",
             $output
         );
 
@@ -189,8 +191,9 @@ final class ServeCommandTest extends TestCase
 
         $output = $commandCreate->getDisplay(true);
 
-        $this->assertStringContainsString(
-            'Routing file is "tests/public/index.php"',
+        $routingFile = preg_quote('tests/public/index.php', '/');
+        $this->assertMatchesRegularExpression(
+            "/Routing file\s+{$routingFile}/",
             $output
         );
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any

## XDebug is installed 

```bash
./yii serve --xdebug
```

<img width="835" alt="image" src="https://user-images.githubusercontent.com/6815714/235347022-6378f8a5-2319-4d87-ac23-a33adfad849c.png">


```bash
./yii serve
```

<img width="873" alt="image" src="https://user-images.githubusercontent.com/6815714/235347121-262c41b3-aa35-49ff-b406-ec76d050d3b6.png">

## XDebug is not installed / loaded 

When `xdebug` extension is not installed / loaded
```bash
./yii serve
```
same for `--xdebug`

<img width="886" alt="image" src="https://user-images.githubusercontent.com/6815714/235347159-1d07fe21-7fa5-4abf-877a-a10a28d5722b.png">

## Verbose

```bash
./yii serve --xdebug -v
```
<img width="1706" alt="image" src="https://user-images.githubusercontent.com/6815714/235347276-e7ebfc4d-0832-46b1-a6fd-fd9fa47749de.png">


```bash
./yii serve -v
```
<img width="1484" alt="image" src="https://user-images.githubusercontent.com/6815714/235347289-77279d33-5f73-4d4e-b791-6cbc983ee273.png">
