### PR TITLE
Fix #172: Fix accepting `:` as command name separator, offer using it by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Bug #172: Fix accepting `:` as command name separator, offer using it by default (samdark) 
 - Enh #180: Enhance output of `serve` command, add `--xdebug` option for `serve` (@xepozz)
-- Bug #179: Remove duplicate message about server address (@samdark)
+- Bug #179: Remove duplicate messages about server address (@samdark)
 
 ## 2.0.1 March 31, 2023
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## 2.0.2 under development
 
-- Bug #179: Remove duplicate message about server address (samdark)
+- Bug #179: Remove duplicate messages about server address (samdark)
+- Bug #172: Fix accepting `:` as command name separator, offer using it by default (samdark) 
 
 ## 2.0.1 March 31, 2023
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## 2.1.0 under development
 
-- Bug #179: Remove duplicate messages about server address (samdark)
 - Bug #172: Fix accepting `:` as command name separator, offer using it by default (samdark) 
 - Enh #180: Enhance output of `serve` command, add `--xdebug` option for `serve` (@xepozz)
 - Bug #179: Remove duplicate message about server address (@samdark)

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ $app->setCommandLoader(new CommandLoader(
 $app->run();
 ```
 
-Since `\Yiisoft\Yii\Console\CommandLoader` uses lazy loading of commands, it is necessary
+Since `\Yiisoft\Yii\Console\CommandLoader` uses lazy loading of commands, it's necessary
 to specify the name and description in static properties when creating a command:
 
 ```php
@@ -69,7 +69,7 @@ use Yiisoft\Yii\Console\ExitCode;
 
 final class MyCustomCommand extends Command
 {
-    protected static $defaultName = 'my/custom';
+    protected static $defaultName = 'my:custom';
     protected static $defaultDescription = 'Description of my custom command.';
     
     protected function configure(): void
@@ -91,7 +91,7 @@ Run the console entry script with your command:
 your-console-entry-script my/custom
 ```
 
-> When naming commands, a slash `/` should be used as a separator. For example: `user/create`, `user/delete`, etc.
+> When naming commands use `:` as a separator. For example: `user:create`, `user:delete`, etc.
 
 
 Since the package is based on [Symfony Console component](https://symfony.com/doc/current/components/console.html),
@@ -170,7 +170,7 @@ The code is statically analyzed with [Psalm](https://psalm.dev/). To run static 
 
 ## License
 
-The Yii Framework Console is free software. It is released under the terms of the BSD License.
+The Yii Framework Console is free software. It's released under the terms of the BSD License.
 Please see [`LICENSE`](./LICENSE.md) for more information.
 
 Maintained by [Yii Software](https://www.yiiframework.com/).

--- a/src/Application.php
+++ b/src/Application.php
@@ -91,9 +91,7 @@ final class Application extends \Symfony\Component\Console\Application
 
     public function extractNamespace(string $name, int $limit = null): string
     {
-        $parts = explode('/', $name, -1);
-
-        return implode('/', null === $limit ? $parts : array_slice($parts, 0, $limit));
+        return parent::extractNamespace(str_replace('/', ':', $name), $limit);
     }
 
     public function getNamespaces(): array

--- a/src/Application.php
+++ b/src/Application.php
@@ -14,10 +14,8 @@ use Yiisoft\FriendlyException\FriendlyExceptionInterface;
 use Yiisoft\Yii\Console\Event\ApplicationShutdown;
 use Yiisoft\Yii\Console\Event\ApplicationStartup;
 
-use function array_slice;
 use function count;
 use function explode;
-use function implode;
 
 final class Application extends \Symfony\Component\Console\Application
 {

--- a/tests/ApplicationTest.php
+++ b/tests/ApplicationTest.php
@@ -115,11 +115,11 @@ final class ApplicationTest extends TestCase
     public function namespaceProvider(): array
     {
         return [
-            ['first/second/third', null, 'first/second'],
+            ['first/second/third', null, 'first:second'],
             ['first/second/third', 1, 'first'],
-            ['first/second/third', 2, 'first/second'],
-            ['first/second/third', 3, 'first/second'],
-            ['first/second/third', 4, 'first/second'],
+            ['first/second/third', 2, 'first:second'],
+            ['first/second/third', 3, 'first:second'],
+            ['first/second/third', 4, 'first:second'],
         ];
     }
 


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #172
