### PR TITLE
Allow to use `ErrorListiner` without logger + Minor refactoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2.1.3 under development
 
-- no changes in this release.
+- Enh #194: Allow to use `ErrorListiner` without logger (@vjik)
 
 ## 2.1.2 December 26, 2023
 
@@ -14,7 +14,7 @@
 
 ## 2.1.0 May 28, 2023
 
-- Bug #172: Fix accepting `:` as command name separator, offer using it by default (samdark)
+- Bug #172: Fix accepting `:` as command name separator, offer using it by default (@samdark)
 - Bug #179: Remove duplicate messages about server address (@samdark)
 - Enh #180: Enhance output of `serve` command, add `--xdebug` option for `serve` (@xepozz)
 

--- a/src/ErrorListener.php
+++ b/src/ErrorListener.php
@@ -15,9 +15,6 @@ final class ErrorListener
     {
     }
 
-    /**
-     * @psalm-suppress PossiblyNullArgument
-     */
     public function onError(ConsoleErrorEvent $event): void
     {
         if ($this->logger === null) {
@@ -27,15 +24,13 @@ final class ErrorListener
         $exception = $event->getError();
         $command = $event->getCommand();
 
-        $commandName = ($command !== null && $command->getName() !== null) ? $command->getName() : 'unknown';
-
         $message = sprintf(
             '%s: %s in %s:%s while running console command "%s".',
             $exception::class,
             $exception->getMessage(),
             $exception->getFile(),
             $exception->getLine(),
-            $commandName,
+            $command?->getName() ?? 'unknown',
         );
 
         $this->logger->error($message, ['exception' => $exception]);

--- a/src/ErrorListener.php
+++ b/src/ErrorListener.php
@@ -11,7 +11,7 @@ use function sprintf;
 
 final class ErrorListener
 {
-    public function __construct(private LoggerInterface $logger)
+    public function __construct(private ?LoggerInterface $logger = null)
     {
     }
 
@@ -20,6 +20,10 @@ final class ErrorListener
      */
     public function onError(ConsoleErrorEvent $event): void
     {
+        if ($this->logger === null) {
+            return;
+        }
+
         $exception = $event->getError();
         $command = $event->getCommand();
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | -

After this PR need to create new issue: "Make logger in `ErrorListener` required, and remove event from package configuration"