### PR TITLE
Fix #205: Use annotations in README command example

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,8 +151,11 @@ To configure default settings, set the options in `\Yiisoft\Yii\Console\CommandL
 ],
 ```
 
-Alternatively, you can pass the settings through the console options. To see the available options, run
-`./yii serve --help`
+Alternatively, you can pass the settings through the console options.
+
+> Tip: To run a web server with XDebug enabled, pass `--xdebug 1` to the command.
+
+To see the available options, run `./yii serve --help`.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -74,14 +74,17 @@ Since `\Yiisoft\Yii\Console\CommandLoader` uses lazy loading of commands, it's n
 to specify the name and description in static properties when creating a command:
 
 ```php
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Yiisoft\Yii\Console\ExitCode;
 
+
+#[AsCommand(
+    name: 'my:custom',
+    description: 'Description of my custom command.'
+)]
 final class MyCustomCommand extends Command
-{
-    protected static $defaultName = 'my:custom';
-    protected static $defaultDescription = 'Description of my custom command.';
-    
+{    
     protected function configure(): void
     {
         // ...

--- a/src/Command/Serve.php
+++ b/src/Command/Serve.php
@@ -161,7 +161,7 @@ final class Serve extends Command
             $xDebugInstalled ? sprintf(
                 '%s, %s',
                 phpversion('xdebug'),
-                $xDebugEnabled ? '<info>enabled</>' : '<error>disabled</>',
+                $xDebugEnabled ? '<info>enabled</>' : '<error>disabled. Add --xdebug 1 to enable</>',
             ) : '<error>Not installed</>',
         ];
         $outputTable[] = ['Workers', $isLinux ? $workers : 'Not supported'];

--- a/tests/Stub/StubCommand.php
+++ b/tests/Stub/StubCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Yiisoft\Yii\Console\Tests\Stub;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -12,11 +13,12 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 use Yiisoft\Yii\Console\Application;
 use Yiisoft\Yii\Console\ExitCode;
 
+#[AsCommand(
+    name: 'stub',
+    description: 'Stub command tests'
+)]
 final class StubCommand extends Command
 {
-    protected static $defaultName = 'stub';
-    protected static $defaultDescription = 'Stub command tests';
-
     public function configure(): void
     {
         $this->addOption('styled', 's', InputOption::VALUE_OPTIONAL);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #205
