### PR TITLE
Check empty string as key in command map in `CommandLoader` validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2.3.1 under development
 
-- no changes in this release.
+- Enh #226: Check empty string as key in command map in `CommandLoader` validation (@vjik)
 
 ## 2.3.0 January 23, 2025
 

--- a/src/CommandLoader.php
+++ b/src/CommandLoader.php
@@ -114,8 +114,6 @@ final class CommandLoader implements CommandLoaderInterface
                 array_shift($aliases);
             }
 
-            /** @var string[] $aliases Fix for psalm. See {@link https://github.com/vimeo/psalm/issues/9261}. */
-
             $this->validateAliases($aliases);
 
             $primaryName = array_shift($aliases);
@@ -137,12 +135,15 @@ final class CommandLoader implements CommandLoaderInterface
     }
 
     /**
-     * @psalm-param string[] $aliases
+     * @psalm-param list<string> $aliases
      *
-     * @psalm-assert non-empty-string[] $aliases
+     * @psalm-assert non-empty-list<non-empty-string> $aliases
      */
     private function validateAliases(array $aliases): void
     {
+        if (empty($aliases)) {
+            throw new RuntimeException('Do not allow empty command name or alias.');
+        }
         foreach ($aliases as $alias) {
             if ($alias === '') {
                 throw new RuntimeException('Do not allow empty command name or alias.');

--- a/tests/CommandLoaderTest.php
+++ b/tests/CommandLoaderTest.php
@@ -15,7 +15,6 @@ use Yiisoft\Yii\Console\Command\Serve;
 use Yiisoft\Yii\Console\CommandLoader;
 use Yiisoft\Yii\Console\Output\ConsoleBufferedOutput;
 use Yiisoft\Yii\Console\Tests\Stub\ErrorCommand;
-
 use Yiisoft\Yii\Console\Tests\Stub\StubCommand;
 
 use function class_exists;

--- a/tests/CommandLoaderTest.php
+++ b/tests/CommandLoaderTest.php
@@ -16,6 +16,8 @@ use Yiisoft\Yii\Console\CommandLoader;
 use Yiisoft\Yii\Console\Output\ConsoleBufferedOutput;
 use Yiisoft\Yii\Console\Tests\Stub\ErrorCommand;
 
+use Yiisoft\Yii\Console\Tests\Stub\StubCommand;
+
 use function class_exists;
 
 final class CommandLoaderTest extends TestCase
@@ -74,6 +76,17 @@ final class CommandLoaderTest extends TestCase
         $this->expectExceptionMessage('Do not allow empty command name or alias.');
 
         new CommandLoader(new SimpleContainer([Serve::class => new Serve()]), ['serve|' => Serve::class]);
+    }
+
+    public function testEmptyCommandAndAlias(): void
+    {
+        $container = new SimpleContainer();
+        $commandMap = ['' => StubCommand::class];
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Do not allow empty command name or alias.');
+
+        new CommandLoader($container, $commandMap);
     }
 
     public function testConstructThrowExceptionIfItIsNotPossibleToCreateCommandObject(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
